### PR TITLE
Added layer_view.html template, alligned MS2 and minor css fixes

### DIFF
--- a/geonode_mapstore_client/client/themes/default/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/default/less/geonode.less
@@ -35,3 +35,6 @@
         position: @geo-bottom-tools-position;
     }
 }
+.timeline-plugin {
+    position: fixed !important;
+}

--- a/geonode_mapstore_client/client/themes/preview/less/geonode.less
+++ b/geonode_mapstore_client/client/themes/preview/less/geonode.less
@@ -55,5 +55,10 @@
     background-color: transparent !important;
     box-shadow: none !important;
 }
-
+.timeline-plugin {
+    position: absolute !important;
+}
+.fill .playback-plugin .ms-playback-settings{
+    bottom: 56px !important;
+}
 @geo-bottom-tools-position: absolute;

--- a/geonode_mapstore_client/hooksets.py
+++ b/geonode_mapstore_client/hooksets.py
@@ -51,7 +51,12 @@ class MapStoreHookSet(GeoExtHookSet):
             if req.GET.get("layer") and req.GET.get("storeType"):
                 return True
         return False
-
+    def isViewLayer(self, context): 
+        if context:
+            req = self.get_request(context)
+            if req.GET.get("layer") and req.GET.get("view"):
+                return True
+        return False
     def initialize_context(self, context, callback):
         if context:
             request = self.get_request(context)
@@ -124,6 +129,8 @@ class MapStoreHookSet(GeoExtHookSet):
         self.initialize_context(context, callback=ms2_config_converter.convert)
         if self.isEditLayer(context):
             return 'geonode-mapstore-client/layer_edit.html'
+        elif self.isViewLayer(context):
+            return 'geonode-mapstore-client/layer_view.html'
         else:
             return 'geonode-mapstore-client/map_new.html'
 

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.2/leaflet.draw.css" />
 {% endif %}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
-<link rel="shortcut icon" type="image/png" href="https://cdn.jslibs.mapstore2.geo-solutions.it/leaflet/favicon.ico" />
+
 {% if MAP_TYPE == "openlayers" %}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/4.6.4/ol.js"></script>
 {% else %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
@@ -1,0 +1,119 @@
+{% extends "./base_ms.html" %}
+{% block plugins %}
+<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
+<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_map_viewer_plugins.js"></script>
+<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_composer_plugins.js"></script>
+{% endblock %}
+{% block style %}
+<style>
+	body {
+        padding-top: 0px !important;
+	}
+	#ms-container {
+		position: absolute;
+		top: 72px;
+		bottom: 0px;
+        width: 100%;
+        z-index: 1029;
+        background-color: white;
+    }
+</style>
+{% endblock %}
+{% block app_config %}
+{% autoescape off %}
+<script type="text/javascript">
+    const geoserver = "{{ OGC_SERVER.default.PUBLIC_LOCATION|default:"" }}";
+    const ms2_config = {{ ms2_config|default:"false" }};
+    document.addEventListener('DOMContentLoaded', function () {
+
+        const userDetails = {
+            "User": user,
+            "access_token": accessToken
+        }
+        MS2_PLUGINS = window.squashMS2PlugCfg(MS2_BASE_PLUGINS, MS2_MAP_PLUGINS, MS2_EDIT_PLUGINS);
+        const stylerCfg = {
+                "name": "StyleEditor",
+                    "cfg": {
+                            "styleService": {
+                                "baseUrl": "{{ SITEURL }}gs/",
+                                "formats": ['css','sld'],
+                                "availableUrls": [geoserver, "{{ SITEURL }}gs/"]
+                        },
+                        "editingAllowedRoles": null
+                    }
+                }
+        MS2_PLUGINS.desktop.push(stylerCfg);
+        MS2_PLUGINS = window.excludeMS2Plugins(MS2_PLUGINS, ["Save", "SaveAs", "Widgets", "WidgetsBuilder"]);
+        MS2_PLUGINS["mobile"] = MS2_PLUGINS.desktop;
+        initMapstore2Api('edit', function(MapStore2) {
+            MapStore2.create('ms-container', {
+                config: ms2_config,
+                mapId: ms2_config.map && ms2_config.map.info && ms2_config.map.info.id,
+                initialState: {
+                    defaultState: {
+                        map: {center: {x: 13, y: 45, crs: "EPSG:4326"}},
+                        maptype: {mapType: maptype},
+                        mode: "embedded",
+                        maps : {
+                            enabled: false,
+                            showMapDetails: true,
+                            errors: [],
+                            searchText: "",
+                            results: ""},
+                        mousePosition: {enabled: false},
+                        controls: {
+                            toolbar: {
+                                active: null,
+                                expanded: false
+                            }
+                        },
+                        mapInfo: {enabled: true, infoFormat: "text/html" },
+                        security: {
+                                token: "{{ ACCESS_TOKEN }}"
+                            }
+                    }
+                },
+                proxy: "{{ SITEURL }}proxy/?url=",
+                printingEnabled: true,
+                localConfig: {
+                    geonode_url: "{{ SITEURL }}",
+                    genode_rest_api: "{{ SITEURL }}mapstore/rest/",
+                    loadAfterTheme: true,
+                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
+                    translations: '',
+                    useAuthenticationRules: true,
+                    authenticationRules: [{
+                        "urlPattern": ".*geostore.*",
+                        "method": "bearer"
+                    }, {
+                        "urlPattern": ".*geoserver.*",
+                        "authkeyParamName": "access_token",
+                        "method": "authkey"
+                    }]
+                },
+                plugins: MS2_PLUGINS
+            });
+            if (ms2_config) {
+                MapStore2.triggerAction({
+                    type: "MAP_CONFIG_LOADED",
+                    config: ms2_config,
+                    legacy: !!ms2_config.map && ms2_config.map.info && ms2_config.map.info.id,
+                    mapId: ms2_config.map && ms2_config.map.info && ms2_config.map.info.id
+                });
+            }
+            if (user && user.id) {
+                MapStore2.triggerAction({type: "LOGIN_SUCCESS", userDetails});
+            }
+        });
+    });
+</script>
+{% endautoescape %}
+{% endblock %}
+{% block map_content %}
+<div id="ms-container" class="ms2">
+        <div class="_ms2_init_spinner _ms2_init_center">
+            <div></div>
+        </div>
+        <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Added layer_view template, when in layer view ms2 is opened with featuregrid editor and styleeditror plugin closed, but if the user has layer edit permission he is able to edit data and style for the layer.
Minor fixes to css