### PR TITLE
Updated MapStore submodule

### DIFF
--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
@@ -39,7 +39,8 @@
                                 "formats": ['css','sld'],
                                 "availableUrls": [geoserver, "{{ SITEURL }}gs/"]
                         },
-                        "editingAllowedRoles": null
+                        "editingAllowedRoles": null,
+                        "enableSetDefaultStyle": true
                     }
                 }
         MS2_PLUGINS.desktop.push(stylerCfg);


### PR DESCRIPTION
Style editor improvements:
- Fix #127 Set default style of layer from the ui 
- https://github.com/geosolutions-it/MapStore2/issues/3473
- https://github.com/geosolutions-it/MapStore2/issues/3375

Timeline improvements:
- https://github.com/geosolutions-it/MapStore2/issues/3442
- https://github.com/geosolutions-it/MapStore2/pull/3488
- https://github.com/geosolutions-it/MapStore2/issues/3463
- https://github.com/geosolutions-it/MapStore2/issues/3442
- https://github.com/geosolutions-it/MapStore2/issues/3397

@kappu72 could you verify if `"enableSetDefaultStyle": true` is enabled only in the layer page with this commit?
this flag enables this functionality https://github.com/geosolutions-it/MapStore2/pull/3472