### PR TITLE
Update MapStore2 submodule to the last release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "geonode_mapstore_client/client/MapStore2"]
 	path = geonode_mapstore_client/client/MapStore2
 	url = https://github.com/geosolutions-it/MapStore2.git
-	branch = gc127_geonode_integration
+	branch = 2019.01.xx


### PR DESCRIPTION
With this PR the MapStore2 submodule has been updated to point the new MapStore release (https://github.com/geosolutions-it/MapStore2/tree/v2019.01.00).
Related to #142 