### PR TITLE
Fix merge dependencies in package.json

### DIFF
--- a/geonode_mapstore_client/client/mergeDependencies.js
+++ b/geonode_mapstore_client/client/mergeDependencies.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var msP = JSON.parse(fs.readFileSync("./MapStore2/package.json", "utf8"));
 var projP = JSON.parse(fs.readFileSync("./package.json", "utf8"));
-var devDependencies = {...msP.devDependencies,  ...(projP.devDependencies || {})};
-var dependencies = {...msP.dependencies,  ...(projP.dependencies || {})};
-fs.writeFileSync("./package.json", JSON.stringify({...projP, devDependencies, dependencies}), "utf8");
+var devDependencies = {...(projP.devDependencies || {}), ...msP.devDependencies};
+var dependencies = {...(projP.dependencies || {}), ...msP.dependencies};
+fs.writeFileSync("./package.json", JSON.stringify({...projP, devDependencies, dependencies}, null, 2), "utf8");


### PR DESCRIPTION
With this PR the `mergeDependeciens.js` script (called by `preinstall`) has been changed to enable the packages updating from MapStore2.

The variables `devDependencies` and `dependencies` are now created adding the MapStore2 dependencies after the existing ones. In the case of a key collision, the right-most (last) object's value wins out.

Example:
```
var prjDep = {
  dep_1: 'd1_v0',
  dep_2: 'd2_v0'
};
var ms2Dep = { 
  dep_1: 'd1_v1',
  dep_3: 'd3_v0' 
};
var mergedDep = {...prjDep, ...ms2Dep};
```
Results:
```
Object {
  dep_1: 'd1_v1', 
  dep_2: 'd2_v0',
  dep_3: 'd3_v0'
}
```

Fix #137 