### PR TITLE
Fix #138 Problems in translations of label and menù in GeoNode-MapStore integration

### DIFF
--- a/geonode_mapstore_client/client/js/api.js
+++ b/geonode_mapstore_client/client/js/api.js
@@ -8,6 +8,7 @@
 require('react-widgets/dist/css/react-widgets.css');
 const assign = require("object-assign");
 const ConfigUtils = require('../MapStore2/web/client/utils/ConfigUtils');
+const LocaleUtils = require('../MapStore2/web/client/utils/LocaleUtils');
 const {keyBy, values} = require('lodash');
 /**
  * Add custom (overriding) translations with:
@@ -74,14 +75,24 @@ const createMapStore2Api = function(plugins) {
 };
 // Can be used to define more compact plugins bundle
 window.initMapstore2Api = function(config, resolve) {
+
+    // force supported locales to the selected one
+    const setLocale = (localeKey) => {
+        const supportedLocales = LocaleUtils.getSupportedLocales();
+        const locale = supportedLocales[localeKey]
+            ? { [localeKey]: supportedLocales[localeKey] }
+            : { en: supportedLocales.en };
+        LocaleUtils.setSupportedLocales(locale);
+    };
+
     require(`./components/${maptype}/ArcGisMapServer`);// eslint-disable-line
     if (config === 'preview') {
         require.ensure('./previewPlugins', function() {
-            resolve(createMapStore2Api(require('./previewPlugins')));
+            resolve(createMapStore2Api(require('./previewPlugins')), { setLocale });
         });
     }else {
         require.ensure('./plugins', function() {
-            resolve(createMapStore2Api(require('./plugins')));
+            resolve(createMapStore2Api(require('./plugins')), { setLocale });
         });
     }
 };

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/edit_map.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/edit_map.html
@@ -29,9 +29,12 @@
             "User": user,
             "access_token": accessToken
         }
-        initMapstore2Api('edit', function(MapStore2) {
+        initMapstore2Api('edit', function(MapStore2, options) {
             // you have to add the configuration for stylerplugin
             MS2_PLUGINS = window.squashMS2PlugCfg(MS2_BASE_PLUGINS, MS2_MAP_PLUGINS, MS2_EDIT_PLUGINS);
+            if (options && options.setLocale) {
+                options.setLocale({{ locale }});
+            }
             const stylerCfg = {
                 "name": "StyleEditor",
                     "cfg": {

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_edit.html
@@ -33,7 +33,10 @@
         MS2_PLUGINS = window.squashMS2PlugCfg(MS2_BASE_PLUGINS, MS2_MAP_PLUGINS, MS2_EDIT_PLUGINS);
         MS2_PLUGINS = window.excludeMS2Plugins(MS2_PLUGINS, ["Save", "SaveAs","WidgetsBuilder","Widgets"]);
         MS2_PLUGINS["mobile"] = MS2_PLUGINS.desktop;
-        initMapstore2Api('edit', function(MapStore2) {
+        initMapstore2Api('edit', function(MapStore2, options) {
+            if (options && options.setLocale) {
+                options.setLocale({{ locale }});
+            }
             MapStore2.create('ms-container', {
                 config: ms2_config,
                 mapId: ms2_config.map && ms2_config.map.info && ms2_config.map.info.id,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_map.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_map.html
@@ -28,7 +28,10 @@
         $('#embedded_map').html('<div class="_ms2_init_spinner _ms2_init_center"><div></div> <div class="_ms2_init_text _ms2_init_center">Loading MapStore</div>');
         MS2_PLUGINS = MS2_BASE_PLUGINS;
         MS2_PLUGINS["mobile"] = MS2_PLUGINS.desktop;
-        initMapstore2Api('preview', function(MapStore2) {
+        initMapstore2Api('preview', function(MapStore2, options) {
+            if (options && options.setLocale) {
+                options.setLocale({{ locale }});
+            }
             MapStore2.create('embedded_map', {
                 mode: "embedded",
                 config: ms2_config,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
@@ -46,7 +46,10 @@
         MS2_PLUGINS.desktop.push(stylerCfg);
         MS2_PLUGINS = window.excludeMS2Plugins(MS2_PLUGINS, ["Save", "SaveAs", "Widgets", "WidgetsBuilder"]);
         MS2_PLUGINS["mobile"] = MS2_PLUGINS.desktop;
-        initMapstore2Api('edit', function(MapStore2) {
+        initMapstore2Api('edit', function(MapStore2, options) {
+            if (options && options.setLocale) {
+                options.setLocale({{ locale }});
+            }
             MapStore2.create('ms-container', {
                 config: ms2_config,
                 mapId: ms2_config.map && ms2_config.map.info && ms2_config.map.info.id,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
@@ -45,7 +45,10 @@
         MS2_PLUGINS.desktop.push(stylerCfg);
         MS2_PLUGINS = window.excludeMS2Plugins(MS2_PLUGINS, ["Save", "SaveAs", "Widgets", "WidgetsBuilder"]);
         MS2_PLUGINS["mobile"] = MS2_PLUGINS.desktop;
-        initMapstore2Api('edit', function(MapStore2) {
+        initMapstore2Api('edit', function(MapStore2, options) {
+            if (options && options.setLocale) {
+                options.setLocale({{ locale }});
+            }
             MapStore2.create('ms-container', {
                 config: ms2_config,
                 mapId: ms2_config.map && ms2_config.map.info && ms2_config.map.info.id,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
@@ -22,7 +22,10 @@
         }
         MS2_PLUGINS = window.squashMS2PlugCfg(MS2_BASE_PLUGINS, MS2_EMBED_PLUGINS);
         MS2_PLUGINS["mobile"] = MS2_PLUGINS.desktop;
-        initMapstore2Api('edit', function(MapStore2) { 
+        initMapstore2Api('edit', function(MapStore2, options) {
+            if (options && options.setLocale) {
+                options.setLocale({{ locale }});
+            }
             MapStore2.create('ms-container', {
                 config: ms2_config,
                 mapId: ms2_config.map && ms2_config.map.info && ms2_config.map.info.id,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_view.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_view.html
@@ -62,7 +62,7 @@
                 proxy: "{{ SITEURL }}proxy/?url=",
                 printingEnabled: true,
                 localConfig: {
-                    disableCheckEditPermissions: false,
+                    disableCheckEditPermissions: true,
                     geonode_url: "{{ SITEURL }}",
                     genode_rest_api: "{{ SITEURL }}mapstore/rest/",
                     loadAfterTheme: true,


### PR DESCRIPTION
Fix #138 

This PR add an options param to `initMapstore2Api`, inside options can be find the `setLocale` function.
setLocale updates supported locales of MapStore with a single locale object that match the localeKey (with this approach MapStore is forced to use the selected locale).
If the localKey is not supported, MapStore will use `en` locale.
example:
```js
if (options && options.setLocale) {
  var localeKey = 'it';
  options.setLocale(localeKey);
}
```