### PR TITLE
Dynamic URLs and centralised settings

### DIFF
--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_client_composer_js.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_client_composer_js.html
@@ -11,10 +11,10 @@
 {%  if MAP_DEBUG %}
 <script id="ms2-api" src="http://localhost:8081/dist/ms2-geonode-api.js"></script>
 {% else %}
-<script id="ms2-api" src="{{ STATIC_URL }}mapstore/dist/ms2-geonode-api.js"></script>
+<script id="ms2-api" src="{% static 'mapstore/dist/ms2-geonode-api.js' %}"></script>
 {% endif %}
 
 <!-- script to generate Thumbnails from MapStore -->
-<script type="text/javascript" src="{{ STATIC_URL}}geonode/js/ms2/utils/thumbnail.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/thumbnail.js' %}"></script>
 
-<script type="text/javascript" src="{{ STATIC_URL}}geonode/js/ms2/utils/ms2_composer_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_composer_plugins.js' %}"></script>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_client_viewer_js.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_client_viewer_js.html
@@ -11,11 +11,11 @@
 {%  if MAP_DEBUG %}
 <script id="ms2-api" src="http://localhost:8081/dist/ms2-geonode-api.js"></script>
 {% else %}
-<script id="ms2-api" src="{{ STATIC_URL }}mapstore/dist/ms2-geonode-api.js"></script>
+<script id="ms2-api" src="{% static 'mapstore/dist/ms2-geonode-api.js' %}"></script>
 {% endif %}
 
 <!-- script to generate Thumbnails from MapStore -->
-<script type="text/javascript" src="{{ STATIC_URL}}geonode/js/ms2/utils/thumbnail.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/thumbnail.js' %}"></script>
 
 <!-- MapStore2 specific stuff -->
-<script type="text/javascript" src="{{ STATIC_URL}}geonode/js/ms2/utils/ms2_viewer_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_viewer_plugins.js' %}"></script>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_config.html
@@ -1,0 +1,27 @@
+<script>
+  const defaultConfig = {
+    proxy: "{{ SITEURL }}{{ PROXY_URL }}",
+    printingEnabled: true,
+    localConfig: {
+      mapLayout: {left: {sm: 300, md: 500, lg: 600}, right: {md: "41%"}, bottom: {sm: 0}},
+      geonode_url: "{{ SITEURL }}",
+      genode_rest_api: "{{ SITEURL }}mapstore/rest/",
+      printUrl: "{{ GEOSERVER_PUBLIC_LOCATION }}gs/pdf/info.json",
+      translations: '',
+      useAuthenticationRules: true,
+      loadAfterTheme: true,
+      authenticationRules: [{
+        "urlPattern": ".*geostore.*",
+        "method": "bearer"
+      }, {
+        "urlPattern": ".*geoserver.*",
+        "authkeyParamName": "access_token",
+        "method": "authkey"
+      }, {
+        "urlPattern": ".*gs.*",
+        "authkeyParamName": "access_token",
+        "method": "authkey"
+      }]
+    }
+  }
+</script>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/_config.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/_config.html
@@ -6,7 +6,7 @@
       mapLayout: {left: {sm: 300, md: 500, lg: 600}, right: {md: "41%"}, bottom: {sm: 0}},
       geonode_url: "{{ SITEURL }}",
       genode_rest_api: "{{ SITEURL }}mapstore/rest/",
-      printUrl: "{{ GEOSERVER_PUBLIC_LOCATION }}gs/pdf/info.json",
+      printUrl: "{{ GEOSERVER_PUBLIC_LOCATION }}pdf/info.json",
       translations: '',
       useAuthenticationRules: true,
       loadAfterTheme: true,

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
@@ -22,11 +22,11 @@
 {%  if MAP_DEBUG %}
 <script id="ms2-api" src="http://localhost:8081/dist/ms2-geonode-api.js"></script>
 {% else %}
-<script id="ms2-api" src="{{ STATIC_URL }}mapstore/dist/ms2-geonode-api.js"></script>
+<script id="ms2-api" src="{% static 'mapstore/dist/ms2-geonode-api.js' %}"></script>
 {% endif %}
 
 <!-- script to generate Thumbnails from MapStore -->
-<script type="text/javascript" src="{{ STATIC_URL}}geonode/js/ms2/utils/thumbnail.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/thumbnail.js' %}"></script>
 
 {% block plugins %}
 <!-- load plugins config-->

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/base_ms.html
@@ -123,6 +123,7 @@
 
 {% endautoescape %}
 {% endwith %}
+{% include './_config.html' %}
 {% block app_config %}{% endblock %}
 
 {% block map_content %}

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/edit_map.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/edit_map.html
@@ -76,27 +76,16 @@
                             }
                     }
                 },
-                proxy: "{{ SITEURL }}proxy/?url=",
-                printingEnabled: true,
+                proxy: defaultConfig.proxy,
+                printingEnabled: defaultConfig.printingEnabled,
                 localConfig: {
-                    geonode_url: "{{ SITEURL }}",
-                    genode_rest_api: "{{ SITEURL }}mapstore/rest/",
-                    loadAfterTheme: true,
-                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
-                    translations: '',
-                    useAuthenticationRules: true,
-                    authenticationRules: [{
-                        "urlPattern": ".*geostore.*",
-                        "method": "bearer"
-                    }, {
-                        "urlPattern": ".*geoserver.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }, {
-                        "urlPattern": ".*gs.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }]
+                    geonode_url: defaultConfig.localConfig.geonode_url,
+                    genode_rest_api: defaultConfig.localConfig.genode_rest_api,
+                    loadAfterTheme: defaultConfig.localConfig.loadAfterTheme,
+                    printUrl: defaultConfig.localConfig.printUrl,
+                    translations: defaultConfig.localConfig.translations,
+                    useAuthenticationRules: defaultConfig.localConfig.useAuthenticationRules,
+                    authenticationRules: defaultConfig.localConfig.authenticationRules
                 },
                 plugins: MS2_PLUGINS
             });

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/edit_map.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/edit_map.html
@@ -1,8 +1,9 @@
 {% extends "./base_ms.html" %}
+{% load static %}
 {% block plugins %}
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_map_viewer_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_composer_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_base_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_map_viewer_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_composer_plugins.js' %}"></script>
 {% endblock %}
 {% block style %}
 <style>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_edit.html
@@ -65,27 +65,16 @@
                             }
                     }
                 },
-                proxy: "{{ SITEURL }}proxy/?url=",
-                printingEnabled: true,
+                proxy: defaultConfig.proxy,
+                printingEnabled: defaultConfig.printingEnabled,
                 localConfig: {
-                    geonode_url: "{{ SITEURL }}",
-                    genode_rest_api: "{{ SITEURL }}mapstore/rest/",
-                    loadAfterTheme: true,
-                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
-                    translations: '',
-                    useAuthenticationRules: true,
-                    authenticationRules: [{
-                        "urlPattern": ".*geostore.*",
-                        "method": "bearer"
-                    }, {
-                        "urlPattern": ".*geoserver.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }, {
-                        "urlPattern": ".*gs.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }]
+                    geonode_url: defaultConfig.localConfig.geonode_url,
+                    genode_rest_api: defaultConfig.localConfig.genode_rest_api,
+                    loadAfterTheme: defaultConfig.localConfig.loadAfterTheme,
+                    printUrl: defaultConfig.localConfig.printUrl,
+                    translations: defaultConfig.localConfig.translations,
+                    useAuthenticationRules: defaultConfig.localConfig.useAuthenticationRules,
+                    authenticationRules: defaultConfig.localConfig.authenticationRules
                 },
                 plugins: MS2_PLUGINS
             });

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_edit.html
@@ -1,8 +1,9 @@
 {% extends "./base_ms.html" %}
+{% load static %}
 {% block plugins %}
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_map_viewer_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_composer_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_base_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_map_viewer_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_composer_plugins.js' %}"></script>
 {% endblock %}
 {% block style %}
 <style>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_map.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_map.html
@@ -54,27 +54,16 @@
                         }
                     }
                 },
-                proxy: "{{ SITEURL }}proxy/?url=",
-                printingEnabled: true,
+                proxy: defaultConfig.proxy,
+                printingEnabled: defaultConfig.printingEnabled,
                 localConfig: {
-                    mapLayout: {left: {sm: 300, md: 500, lg: 600}, right: {md: "41%"}, bottom: {sm: 0}},
-                    geonode_url: "{{ SITEURL }}",
-                    translations: '',
-                    loadAfterTheme: true,
-                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
-                    useAuthenticationRules: true,
-                    authenticationRules: [{
-                        "urlPattern": ".*geostore.*",
-                        "method": "bearer"
-                    }, {
-                        "urlPattern": ".*geoserver.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }, {
-                        "urlPattern": ".*gs.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }]
+                    mapLayout: defaultConfig.localConfig.mapLayout,
+                    geonode_url: defaultConfig.localConfig.geonode_url,
+                    translations: defaultConfig.localConfig.translations,
+                    loadAfterTheme: defaultConfig.localConfig.loadAfterTheme,
+                    printUrl: defaultConfig.localConfig.printUrl,
+                    useAuthenticationRules: defaultConfig.localConfig.useAuthenticationRules,
+                    authenticationRules: defaultConfig.localConfig.authenticationRules
                 },
                 plugins: MS2_PLUGINS
             });

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_map.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_map.html
@@ -1,6 +1,7 @@
 {% extends "./base_ms.html" %}
+{% load static %}
 {% block plugins %}
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_base_plugins.js' %}"></script>
 {% endblock %}
 {% block style %}
 <style>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
@@ -78,27 +78,16 @@
                             }
                     }
                 },
-                proxy: "{{ SITEURL }}proxy/?url=",
-                printingEnabled: true,
+                proxy: defaultConfig.proxy,
+                printingEnabled: defaultConfig.printingEnabled,
                 localConfig: {
-                    geonode_url: "{{ SITEURL }}",
-                    genode_rest_api: "{{ SITEURL }}mapstore/rest/",
-                    loadAfterTheme: true,
-                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
-                    translations: '',
-                    useAuthenticationRules: true,
-                    authenticationRules: [{
-                        "urlPattern": ".*geostore.*",
-                        "method": "bearer"
-                    }, {
-                        "urlPattern": ".*geoserver.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }, {
-                        "urlPattern": ".*gs.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }]
+                    geonode_url: defaultConfig.localConfig.geonode_url,
+                    genode_rest_api: defaultConfig.localConfig.genode_rest_api,
+                    loadAfterTheme: defaultConfig.localConfig.loadAfterTheme,
+                    printUrl: defaultConfig.localConfig.printUrl,
+                    translations: defaultConfig.localConfig.translations,
+                    useAuthenticationRules: defaultConfig.localConfig.useAuthenticationRules,
+                    authenticationRules: defaultConfig.localConfig.authenticationRules
                 },
                 plugins: MS2_PLUGINS
             });

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_style_edit.html
@@ -1,8 +1,9 @@
 {% extends "./base_ms.html" %}
+{% load static %}
 {% block plugins %}
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_map_viewer_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_composer_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_base_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_map_viewer_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_composer_plugins.js' %}"></script>
 {% endblock %}
 {% block style %}
 <style>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
@@ -78,27 +78,16 @@
                             }
                     }
                 },
-                proxy: "{{ SITEURL }}proxy/?url=",
-                printingEnabled: true,
+                proxy: defaultConfig.proxy,
+                printingEnabled: defaultConfig.printingEnabled,
                 localConfig: {
-                    geonode_url: "{{ SITEURL }}",
-                    genode_rest_api: "{{ SITEURL }}mapstore/rest/",
-                    loadAfterTheme: true,
-                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
-                    translations: '',
-                    useAuthenticationRules: true,
-                    authenticationRules: [{
-                        "urlPattern": ".*geostore.*",
-                        "method": "bearer"
-                    }, {
-                        "urlPattern": ".*geoserver.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }, {
-                        "urlPattern": ".*gs.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }]
+                    geonode_url: defaultConfig.localConfig.geonode_url,
+                    genode_rest_api: defaultConfig.localConfig.genode_rest_api,
+                    loadAfterTheme: defaultConfig.localConfig.loadAfterTheme,
+                    printUrl: defaultConfig.localConfig.printUrl,
+                    translations: defaultConfig.localConfig.translations,
+                    useAuthenticationRules: defaultConfig.localConfig.useAuthenticationRules,
+                    authenticationRules: defaultConfig.localConfig.authenticationRules
                 },
                 plugins: MS2_PLUGINS
             });

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/layer_view.html
@@ -1,8 +1,9 @@
 {% extends "./base_ms.html" %}
+{% load static %}
 {% block plugins %}
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_map_viewer_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_composer_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_base_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_map_viewer_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_composer_plugins.js' %}"></script>
 {% endblock %}
 {% block style %}
 <style>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
@@ -1,7 +1,8 @@
 {% extends "./base_ms.html" %}
+{% load static %}
 {% block plugins %}
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_map_embed_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_base_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_map_embed_plugins.js' %}"></script>
 {% endblock %}
 {% block style %}
 <style>

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_embed.html
@@ -54,27 +54,16 @@
                             }
                     }
                 },
-                proxy: "{{ SITEURL }}proxy/?url=",
-                printingEnabled: true,
+                proxy: defaultConfig.proxy,
+                printingEnabled: defaultConfig.printingEnabled,
                 localConfig: {
-                    geonode_url: "{{ SITEURL }}",
-                    genode_rest_api: "{{ SITEURL }}mapstore/rest/",
-                    loadAfterTheme: true,
-                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
-                    translations: '',
-                    useAuthenticationRules: true,
-                    authenticationRules: [{
-                        "urlPattern": ".*geostore.*",
-                        "method": "bearer"
-                    }, {
-                        "urlPattern": ".*geoserver.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }, {
-                        "urlPattern": ".*gs.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }]
+                    geonode_url: defaultConfig.localConfig.geonode_url,
+                    genode_rest_api: defaultConfig.localConfig.genode_rest_api,
+                    loadAfterTheme: defaultConfig.localConfig.loadAfterTheme,
+                    printUrl: defaultConfig.localConfig.printUrl,
+                    translations: defaultConfig.localConfig.translations,
+                    useAuthenticationRules: defaultConfig.localConfig.useAuthenticationRules,
+                    authenticationRules: defaultConfig.localConfig.authenticationRules
                 },
                 plugins: MS2_PLUGINS
             });

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_view.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_view.html
@@ -60,28 +60,17 @@
                             }
                     }
                 },
-                proxy: "{{ SITEURL }}proxy/?url=",
-                printingEnabled: true,
+                proxy: defaultConfig.proxy,
+                printingEnabled: defaultConfig.printingEnabled,
                 localConfig: {
                     disableCheckEditPermissions: true,
-                    geonode_url: "{{ SITEURL }}",
-                    genode_rest_api: "{{ SITEURL }}mapstore/rest/",
-                    loadAfterTheme: true,
-                    printUrl: "{{ SITEURL }}gs/pdf/info.json",
-                    translations: '',
-                    useAuthenticationRules: true,
-                    authenticationRules: [{
-                        "urlPattern": ".*geostore.*",
-                        "method": "bearer"
-                    }, {
-                        "urlPattern": ".*geoserver.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }, {
-                        "urlPattern": ".*gs.*",
-                        "authkeyParamName": "access_token",
-                        "method": "authkey"
-                    }]
+                    geonode_url: defaultConfig.localConfig.geonode_url,
+                    genode_rest_api: defaultConfig.localConfig.genode_rest_api,
+                    loadAfterTheme: defaultConfig.localConfig.loadAfterTheme,
+                    printUrl: defaultConfig.localConfig.printUrl,
+                    translations: defaultConfig.localConfig.translations,
+                    useAuthenticationRules: defaultConfig.localConfig.useAuthenticationRules,
+                    authenticationRules: defaultConfig.localConfig.authenticationRules
                 },
                 plugins: MS2_PLUGINS
             });

--- a/geonode_mapstore_client/templates/geonode-mapstore-client/map_view.html
+++ b/geonode_mapstore_client/templates/geonode-mapstore-client/map_view.html
@@ -1,7 +1,8 @@
 {% extends "./base_ms.html" %}
+{% load static %}
 {% block plugins %}
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_base_plugins.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}geonode/js/ms2/utils/ms2_map_viewer_plugins.js"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_base_plugins.js' %}"></script>
+<script type="text/javascript" src="{% static 'geonode/js/ms2/utils/ms2_map_viewer_plugins.js' %}"></script>
 {% endblock %}
 
 {% block style %}


### PR DESCRIPTION
This PR does two things (sorry):

1. It uses Django's `{% static %}` template tag to generate static URLs, rather than the `{{ STATIC_URL }}` setting. The difference being that the template tag is aware of Django's static file storage backend (and can deal with dynamic URLs much easier), while `{{ STATIC_URL }}` is just a setting. 

2. It pulls the javascript configuration repeated in multiple templates into a single location so that URL and setting changes can be done at only one point in the code. There are nicer ways to do this, but it's a start :-)

This closes #169

